### PR TITLE
Strip whitespace from the ip address (since this seems to break on he…

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -23,7 +23,7 @@ class IpRestrictionMiddleware(object):
         else:
             ip = request.META.get('REMOTE_ADDR')
 
-        return ip
+        return ip.strip()
 
     def process_request(self, request):
         if getattr(settings, 'RESTRICT_IPS', False):

--- a/navigator/settings/base.py
+++ b/navigator/settings/base.py
@@ -134,4 +134,5 @@ WHOOSH_INDEX_DIR = os.path.join(BASE_DIR, 'whoosh_index')
 
 DEBUG = False
 
-RESTRICT_IPS = os.environ.get('RESTRICT_IPS', False)
+ip_check = os.environ.get('RESTRICT_IPS', False)
+RESTRICT_IPS = ip_check == 'True' or ip_check == '1'


### PR DESCRIPTION
…roku), and allow for non-boolean env vars