### PR TITLE
Omit the mature category on ministerial orders, to reduce the risk of…

### DIFF
--- a/navigator/settings/base.py
+++ b/navigator/settings/base.py
@@ -134,3 +134,4 @@ STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 WHOOSH_INDEX_DIR = os.path.join(BASE_DIR, 'whoosh_index')
 
 DEBUG = False
+SESSION_COOKIE_AGE = 43200  # 12 hours

--- a/navigator/settings/dev.py
+++ b/navigator/settings/dev.py
@@ -13,6 +13,3 @@ RESTRICT_IPS = ip_check == 'True' or ip_check == '1'
 
 ALLOWED_IPS = []
 ALLOWED_IP_RANGES = ['165.225.80.0/22', '193.240.203.32/29']
-
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True

--- a/products/management/commands/build_index.py
+++ b/products/management/commands/build_index.py
@@ -40,6 +40,10 @@ class Command(BaseCommand):
             # Get the top-level category name for the row
             category = row[1]
 
+            if category == 'Mature':
+                # Omit the mature category on ministerial orders, to reduce the risk of reputational damage
+                continue
+
             # Go over all columns in the row
             for index in range(2, len(row)):
                 # When you find an empty column, the PREVIOUS column was a leaf sub-category for the main category


### PR DESCRIPTION
… reputational damage

Updated the dev settings since it doesn't run on SSL
Set the session cookies to expire after 12 hours forcing a re-login on admin

pep8