### PR TITLE
stop navigation from expanding on quick page refresh

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -36,6 +36,8 @@
   </head>
   <body class='{% block body_class %}{% endblock %}'>
 
+  <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
   {% block google_tag_manager_noscript %}
     <noscript>
       <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PB37DC" height="0" width="0" style="display:none;visibility:hidden"></iframe>
@@ -203,7 +205,6 @@
         {% endblock footer %}
     </footer>
     {% block footer_javascript %}
-      <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
       <script src="{% static "javascripts/all.js" %}"></script>
     {% endblock footer_javascript %}
   </body>


### PR DESCRIPTION
stop navigation from expanding on quick page refresh