### PR TITLE
overwrite gds font-size, which makes logo to appear bigger

### DIFF
--- a/assets/stylesheets/components/_navigation.scss
+++ b/assets/stylesheets/components/_navigation.scss
@@ -263,6 +263,7 @@
   }
 
   &-logo-link {
+    font-size: 16px;
     margin-bottom: 3px;
   }
 


### PR DESCRIPTION
overwrite gds font-size, which makes logo to appear bigger