### PR TITLE
Add whitenoise for storage

### DIFF
--- a/app/navigator/settings/base.py
+++ b/app/navigator/settings/base.py
@@ -145,27 +145,14 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'fixstatic'),
 )
 
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Media file storage
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
-STORAGE_CLASSES = {
-    'default': 'storages.backends.s3boto3.S3Boto3Storage',
-    'local': 'django.core.files.storage.FileSystemStorage',
-}
-STORAGE_CLASS_NAME = os.getenv('STORAGE_TYPE', 'default')
-DEFAULT_FILE_STORAGE = STORAGE_CLASSES[STORAGE_CLASS_NAME]
-THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
-AWS_ACCESS_KEY_ID = os.environ.get('AWS_KEY_ID')
-AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_KEY')
-AWS_DEFAULT_ACL = 'public-read'
-AWS_QUERYSTRING_AUTH = False
-AWS_S3_ENCRYPTION = False
-AWS_S3_FILE_OVERWRITE = False
-AWS_S3_REGION_NAME = 'eu-west-2'
+THUMBNAIL_DEFAULT_STORAGE = 'django.core.files.storage.FileSystemStorage'
+
 IMAGE_CROPPING_THUMB_SIZE = (710, 537)
 
 # Index location for Whoosh searching

--- a/app/navigator/urls.py
+++ b/app/navigator/urls.py
@@ -17,4 +17,9 @@ urlpatterns = [
     url(r'^markets/', include('markets.urls'), name="markets"),
     url(r'^products/', include('products.urls'), name="products"),
     url(r'^geography/', include('geography.urls'), name="geography"),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    url(
+        r'^media/(?P<path>.*)$',
+        'django.views.static.serve',
+        {'document_root': settings.MEDIA_ROOT}
+    ),
+]


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-3187)

 - django is configured to serve from the webserver
 - django will use reversion in the filename, so updates to the file contents results in a change in the filename e.g, favison-s2342423.ico
 - cloudfront caches the static file
 - cloudfront serves the cached static file, not from the webserver each time