### PR TITLE
Don't 404 on homepage if cms page not found

### DIFF
--- a/app/markets/views.py
+++ b/app/markets/views.py
@@ -24,7 +24,7 @@ from geography.models import Country
 from products.models import Category
 
 from directory_cms_client.client import cms_api_client
-from directory_cms_client.helpers import handle_cms_response
+from directory_cms_client.helpers import handle_cms_response_allow_404
 
 from .models import Market, PublishedMarket
 from .forms import MarketListFilterForm
@@ -67,15 +67,16 @@ class HomepageView(MarketFilterMixin, TemplateView):
             language_code=settings.LANGUAGE_CODE,
             draft_token=self.request.GET.get('draft_token'),
         )
-        return handle_cms_response(response)
+        return handle_cms_response_allow_404(response)
 
     def get_context_data(self, *args, **kwargs):
         """
         Include the count of markets in the context data for showing on the homepage
         """
+        featured_case_studies = self.page.get('featured_case_studies', [])
         return super().get_context_data(
             *args, **kwargs,
-            success_stories=self.page['featured_case_studies'],
+            success_stories=featured_case_studies,
             page_type='LandingPage',
             countries=Country.objects.all().order_by('name'),
             categories=Category.objects.all().order_by('name'),

--- a/app/navigator/tests/test_views.py
+++ b/app/navigator/tests/test_views.py
@@ -44,3 +44,13 @@ def test_homepage_case_studies_cms(mock_cms_page, client):
 
     assert 'Title one' in str(response.content)
     assert 'Title two' in str(response.content)
+
+
+@pytest.mark.django_db
+@mock.patch('directory_cms_client.client.cms_api_client.lookup_by_slug')
+def test_homepage_case_studies_cms_404(mock_cms_page, client):
+    mock_cms_page.return_value = create_response(status_code=404)
+
+    response = client.get(reverse('home'))
+
+    assert response.status_code == 200


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
