### PR TITLE
NOTICKET: Upgrade Django to 2.2.22 (security release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- No Ticket - Django version upgrade to 2.2.22
 - GP2-2381 - corrected contact footer link
 - No ticket - added magna header under feature flag
 - No Ticket - updating team name in error message for internal SSO

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ appdirs==1.4.3
 boto3==1.7.31
 contextlib2==0.5.4
 dj-database-url==0.4.1
-Django>=2.2.20
+Django>=2.2.22
 django-admin-ip-restrictor==1.0.0
 django-appconf==1.0.1
 django-ckeditor==5.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ django-storages==1.5.2
     # via -r requirements.in
 django-thumber==2.0.0
     # via -r requirements.in
-django==2.2.20
+django==2.2.22
     # via
     #   -r requirements.in
     #   directory-client-core

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -79,7 +79,7 @@ django-storages==1.5.2
     # via -r requirements.in
 django-thumber==2.0.0
     # via -r requirements.in
-django==2.2.20
+django==2.2.22
     # via
     #   -r requirements.in
     #   directory-client-core


### PR DESCRIPTION

 - [X] Changelog entry added.
 - [X] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [X] (if updating requirements) Requirements have been compiled.
