### PR TITLE
Add dependabot config and ignore Karma

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "karma"


### PR DESCRIPTION
Karma is a test runner, and as such is never run on, or compiled into code that runs, on production. Any potential attack vector would involve the CI pipeline being compromised: this would point to a wider issue than the codebase itself.

As such, the dependabot alerts related to it can be safely ignored.