### PR TITLE
Disable dependabot automatis PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     ignore:
       - dependency-name: "karma"


### PR DESCRIPTION
By adding ignore config for dependabot, the security scan now defaults to creating pull requests for every dependency update available. This can be disabled by setting the limit to `0`.