### PR TITLE
GLS-328 - Fix typo in commission on markets detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Pre-release
 - GBAU-947 - Removed default special terms message
 - GP2-2841 - Standardisation of python buildpack
+
 ### Fixed bugs
+- GLS-328 - Fix typo in commission on markets detail page
 
 ## [3.2.0](https://github.com/uktrade/navigator/releases/tag/3.2.0)
 

--- a/app/markets/templates/markets/detail.html
+++ b/app/markets/templates/markets/detail.html
@@ -66,7 +66,7 @@
                   <dl class="stats-details">
                     <dt>Registered users:</dt>
                     <dd>{{ market.number_of_registered_users_display }}</dd>
-                    <dt>Commision:</dt>
+                    <dt>Commission:</dt>
                     <dd>{{ market.commission_display|default:"" }}</dd>
                     <dt>Membership fee:</dt>
                     <dd>{{ market.membership_fees_display }}</dd>


### PR DESCRIPTION
This PR fixes a typo on the details page for an individual marketplace, commision -> commis**s**ion.

**Screenshot** 
![Screenshot 2022-07-26 at 16 25 09](https://user-images.githubusercontent.com/22460823/181046653-0e51eb2a-0ab6-4f40-b765-22ddf218dd58.png)

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR
